### PR TITLE
Fix wrong import spec for codemirror-blocks

### DIFF
--- a/spec/languages/pyret/Navigation-test.js
+++ b/spec/languages/pyret/Navigation-test.js
@@ -1,6 +1,6 @@
 import CMB from '../../../src/languages/pyret';
 import 'codemirror/addon/search/searchcursor.js';
-import { TeardownAfterTest } from 'CodeMirror-Blocks';
+import { TeardownAfterTest } from 'codemirror-blocks';
 import { wait } from '../../support/test-utils.js';
 import {
   click,

--- a/spec/languages/pyret/Styling-test.js
+++ b/spec/languages/pyret/Styling-test.js
@@ -1,6 +1,6 @@
 import CMB from '../../../src/languages/pyret';
 import 'codemirror/addon/search/searchcursor.js';
-import { TeardownAfterTest } from 'CodeMirror-Blocks';
+import { TeardownAfterTest } from 'codemirror-blocks';
 import { wait } from '../../support/test-utils.js';
 import {
   _keyPress,

--- a/spec/support/test-utils.js
+++ b/spec/support/test-utils.js
@@ -1,4 +1,4 @@
-import { TeardownAfterTest } from 'CodeMirror-Blocks';
+import { TeardownAfterTest } from 'codemirror-blocks';
 
 export async function wait(ms) {
   return new Promise(resolve => {

--- a/src/languages/pyret/PyretParser.ts
+++ b/src/languages/pyret/PyretParser.ts
@@ -5,7 +5,7 @@ import {
   AST,
   ASTNode,
   Nodes,
-} from 'CodeMirror-Blocks';
+} from 'codemirror-blocks';
 const {
   Blank,
 } = Nodes

--- a/src/languages/pyret/ast.tsx
+++ b/src/languages/pyret/ast.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AST, Pretty as P, DT, Node, Args, Nodes, NodeSpec as Spec} from 'CodeMirror-Blocks';
+import {AST, Pretty as P, DT, Node, Args, Nodes, NodeSpec as Spec} from 'codemirror-blocks';
 
 const {pluralize, enumerateList } = AST;
 const {DropTarget} = DT;

--- a/src/languages/pyret/index.js
+++ b/src/languages/pyret/index.js
@@ -1,5 +1,5 @@
 import PyretParser from './PyretParser';
-import CodeMirrorBlocks  from "CodeMirror-Blocks";
+import CodeMirrorBlocks  from "codemirror-blocks";
 require('./style.less');
 
 export const language = {


### PR DESCRIPTION
Using `import .... from "CodeMirror-Blocks"` should work on machines
with case-insensitive file systems (i.e., OSX), but will throw a
"module could not be found" error on machines with case-sensitive
file systems, where `codemirror-blocks` is the correct path.